### PR TITLE
[Design, Feat] 댓글 컴포넌트 생성

### DIFF
--- a/src/components/Icons/BoardIcons.tsx
+++ b/src/components/Icons/BoardIcons.tsx
@@ -1,4 +1,4 @@
-export const PencilWhiteIcon = () => {
+export const PencilWhiteIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
       width="14"

--- a/src/components/board/BoardCommentCreate/index.tsx
+++ b/src/components/board/BoardCommentCreate/index.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { useCommentCreate } from "../../../hooks/board/comment/useCommentCreate";
+import { useParams } from "react-router-dom";
+import CreateButton from "../../common/createbutton";
+import { CommentInput, CommentLabel } from "./style";
+import FONT from "../../../constants/fonts";
+
+const BoardCommentCreate = () => {
+  const [comment, setComment] = useState("");
+  const { id } = useParams();
+
+  const createMutation = useCommentCreate(parseInt(id!!), comment);
+
+  const handleSubmit = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    createMutation.mutate();
+    setComment("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <CommentLabel>
+        <CommentInput
+          type="text"
+          placeholder="댓글을 남겨주세요"
+          value={comment}
+          onChange={(e) => {
+            setComment(e.target.value);
+          }}
+        />
+        <CreateButton style={FONT.SUBTITLE1} onClick={handleSubmit} />
+      </CommentLabel>
+    </form>
+  );
+};
+
+export default BoardCommentCreate;

--- a/src/components/board/BoardCommentCreate/style.ts
+++ b/src/components/board/BoardCommentCreate/style.ts
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import COLOR from "../../../constants/color";
+
+const CommentInput = styled.input`
+  width: 100%;
+  padding: 1.5rem 1rem;
+  outline: none;
+  border: 2px solid ${COLOR.GRAY0};
+  border-radius: 0.5rem;
+  margin: 1rem 0 1.5rem;
+`;
+
+const CommentLabel = styled.label`
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  button {
+    position: absolute;
+    right: 1rem;
+  }
+`;
+
+export { CommentInput, CommentLabel };

--- a/src/components/board/BoardCommentList/index.tsx
+++ b/src/components/board/BoardCommentList/index.tsx
@@ -1,0 +1,48 @@
+import { useCommentList } from "./../../../hooks/board/comment/useCommentList";
+import { useParams } from "react-router";
+import FONT from "./../../../constants/fonts";
+import { useCommentDelete } from "./../../../hooks/board/comment/useCommentDelete";
+import {
+  CommentButton,
+  CommentButtonBox,
+  CommentContentBox,
+  CommentDate,
+  CommentDetail,
+  CommentInformation,
+  CommentUser,
+} from "./style";
+
+const BoardCommentList = () => {
+  const { id } = useParams();
+
+  const { commentLists } = useCommentList(parseInt(id!!), 1, 5);
+
+  const commentDelete = useCommentDelete(parseInt(id!!));
+
+  return (
+    <div>
+      {commentLists?.comments.map((comment) => (
+        <CommentDetail key={comment.id}>
+          <CommentInformation>
+            <CommentUser style={FONT.SUBTITLE1}>ham0__0</CommentUser>
+            <CommentDate style={FONT.SUBTITLE1}>2023.02.02</CommentDate>
+          </CommentInformation>
+          <CommentContentBox style={FONT.BODY1}>
+            <div>{comment.content}</div>
+            <CommentButtonBox>
+              <CommentButton style={FONT.SUBTITLE1}>수정</CommentButton>
+              <CommentButton
+                style={FONT.SUBTITLE1}
+                onClick={() => commentDelete.mutate(comment.id!!)}
+              >
+                삭제
+              </CommentButton>
+            </CommentButtonBox>
+          </CommentContentBox>
+        </CommentDetail>
+      ))}
+    </div>
+  );
+};
+
+export default BoardCommentList;

--- a/src/components/board/BoardCommentList/style.ts
+++ b/src/components/board/BoardCommentList/style.ts
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+import COLOR from "../../../constants/color";
+
+const CommentDetail = styled.div`
+  padding: 1rem 0;
+`;
+
+const CommentInformation = styled.div`
+  display: flex;
+  margin-bottom: 1rem;
+  color: ${COLOR.GRAY3};
+`;
+
+const CommentUser = styled.div`
+  margin-right: 1rem;
+`;
+
+const CommentDate = styled.div``;
+
+const CommentContentBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const CommentContent = styled.div``;
+
+const CommentButtonBox = styled.div`
+  display: flex;
+  color: ${COLOR.GRAY3};
+`;
+
+const CommentButton = styled.button`
+  cursor: pointer;
+  margin-left: 1rem;
+`;
+
+export {
+  CommentDetail,
+  CommentInformation,
+  CommentUser,
+  CommentDate,
+  CommentContentBox,
+  CommentContent,
+  CommentButtonBox,
+  CommentButton,
+};

--- a/src/components/board/BoardCreate/index.tsx
+++ b/src/components/board/BoardCreate/index.tsx
@@ -13,6 +13,7 @@ import {
   BoardTitleInput,
 } from "./style";
 import { BoardContainer } from "../BoardDetail/style";
+import CreateButton from "../../common/createbutton";
 
 const BoardCreate = () => {
   const [title, setTitle] = useState("");
@@ -71,13 +72,7 @@ const BoardCreate = () => {
           }}
         />
         <BoardButtonContainer>
-          <BoardCreateButton
-            onSubmit={handleCreateSubmit}
-            style={FONT.SUBTITLE1}
-          >
-            <PencilWhiteIcon />
-            작성
-          </BoardCreateButton>
+          <CreateButton style={FONT.SUBTITLE1} onSubmit={handleCreateSubmit} />
         </BoardButtonContainer>
       </form>
     </BoardContainer>

--- a/src/components/board/BoardDetail/index.tsx
+++ b/src/components/board/BoardDetail/index.tsx
@@ -3,6 +3,7 @@ import { useBoardDetail } from "./../../../hooks/board/useBoardDetail";
 import {
   BoardButton,
   BoardButtonBox,
+  BoardCommentCount,
   BoardContainer,
   BoardContent,
   BoardInformation,
@@ -12,6 +13,9 @@ import {
 } from "./style";
 import { useBoardDelete } from "./../../../hooks/board/useBoardDelete";
 import FONT from "./../../../constants/fonts";
+import BoardCommentCreate from "./../BoardCommentCreate/index";
+import BoardCommentList from "./../BoardCommentList/index";
+import { useCommentList } from "../../../hooks/board/comment/useCommentList";
 
 const BoardDetail = () => {
   const navigate = useNavigate();
@@ -27,6 +31,8 @@ const BoardDetail = () => {
     boardDelete.mutate();
     navigate(-1);
   };
+
+  const { commentLists } = useCommentList(parseInt(id!!), 1, 4);
 
   return (
     <>
@@ -58,6 +64,12 @@ const BoardDetail = () => {
           </BoardButtonBox>
         </BoardTopBox>
         <BoardContent style={FONT.BODY1}>{board?.content}</BoardContent>
+
+        <BoardCommentCount style={FONT.SUBTITLE2}>
+          {commentLists?.max_idx}개의 댓글
+        </BoardCommentCount>
+        <BoardCommentCreate />
+        <BoardCommentList />
       </BoardContainer>
     </>
   );

--- a/src/components/board/BoardDetail/style.ts
+++ b/src/components/board/BoardDetail/style.ts
@@ -51,6 +51,12 @@ const BoardContent = styled.div`
   border-bottom: 2px solid ${COLOR.GRAY0};
 `;
 
+const BoardCommentCount = styled.div`
+  color: ${COLOR.GRAY3};
+  padding: 1rem 0;
+  border-bottom: 2px solid ${COLOR.GRAY0};
+`;
+
 export {
   BoardContainer,
   BoardTitle,
@@ -60,4 +66,5 @@ export {
   BoardButtonBox,
   BoardButton,
   BoardContent,
+  BoardCommentCount,
 };

--- a/src/components/character/CharacterList/index.tsx
+++ b/src/components/character/CharacterList/index.tsx
@@ -1,19 +1,19 @@
-import styled from 'styled-components/macro';
-import COLOR from '../../../constants/color';
+import styled from "styled-components/macro";
+import COLOR from "../../../constants/color";
 
-import { waldregAxios } from '../../../apis/axios';
+import { waldregAxios } from "../../../apis/axios";
 
-import usePermissionList from '../../../hooks/character/usePermissionList';
-import useCharacterList from '../../../hooks/character/useCharacterList';
-import useCreateCharacter from '../../../hooks/character/useCreateCharacter';
-import { useInput } from '../../../hooks/common/useInput';
-import { useCheckBox } from '../../../hooks/common/useCheckBox';
+import usePermissionList from "../../../hooks/character/usePermissionList";
+import useCharacterList from "../../../hooks/character/useCharacterList";
+import useCreateCharacter from "../../../hooks/character/useCreateCharacter";
+import { useInput } from "../../../hooks/common/useInput";
+import { useCheckBox } from "../../../hooks/common/useCheckBox";
 
-import { Character } from '../../../interfaces/character';
-import { Title } from '../../common/PageTitle/style';
-import { InputAdd } from '../../common/inputs/input_add';
-import { CheckBox } from '../../common/checkbox/checkbox';
-import { ButtonBig } from '../../common/buttons/button_big';
+import { Character } from "../../../interfaces/character";
+import { Title } from "../../common/pagetitle/style";
+import { InputAdd } from "../../common/inputs/input_add";
+import { CheckBox } from "../../common/checkbox/checkbox";
+import { ButtonBig } from "../../common/buttons/button_big";
 
 const CharacterList = ({ handleClickChangeChar }: any) => {
   const charList = useCharacterList();
@@ -22,17 +22,17 @@ const CharacterList = ({ handleClickChangeChar }: any) => {
 
   const handleClickGetToken = async () => {
     try {
-      const response = await waldregAxios.post('/token', {
-        user_id: 'Admin',
-        user_password: '0000',
+      const response = await waldregAxios.post("/token", {
+        user_id: "Admin",
+        user_password: "0000",
       });
-      localStorage.setItem('accessToken', response.data.access_token);
+      localStorage.setItem("accessToken", response.data.access_token);
     } catch (error) {
       console.log(error);
     }
   };
 
-  const { value, handleChangeInput, reset } = useInput('');
+  const { value, handleChangeInput, reset } = useInput("");
   const { checkedList, updateCheckList, checkReset } = useCheckBox();
 
   const handleClickCreateChar = () => {
@@ -60,7 +60,7 @@ const CharacterList = ({ handleClickChangeChar }: any) => {
           value={value}
           onChange={handleChangeInput}
           reset={reset}
-          placeholder={'추가할 역할 이름을 입력하세요'}
+          placeholder={"추가할 역할 이름을 입력하세요"}
         />
         <CheckBox data={perList || []} updateCheckList={updateCheckList} />
       </Content>

--- a/src/components/character/CharacterSetting/index.tsx
+++ b/src/components/character/CharacterSetting/index.tsx
@@ -1,19 +1,19 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
-import useCharacter from '../../../hooks/character/useCharacter';
-import useEditCharacter from '../../../hooks/character/useEditCharacter';
-import useDeleteCharacter from '../../../hooks/character/useDeleteCharacter';
-import { useInput } from '../../../hooks/common/useInput';
-import { useToggleBox } from '../../../hooks/common/useCheckBox';
+import useCharacter from "../../../hooks/character/useCharacter";
+import useEditCharacter from "../../../hooks/character/useEditCharacter";
+import useDeleteCharacter from "../../../hooks/character/useDeleteCharacter";
+import { useInput } from "../../../hooks/common/useInput";
+import { useToggleBox } from "../../../hooks/common/useCheckBox";
 
-import { Title } from '../../common/PageTitle/style';
-import { InputAdd } from '../../common/inputs/input_add';
-import { ButtonBig } from '../../common/buttons/button_big';
-import PermissionItem from '../Permission';
+import { Title } from "../../common/pagetitle/style";
+import { InputAdd } from "../../common/inputs/input_add";
+import { ButtonBig } from "../../common/buttons/button_big";
+import PermissionItem from "../Permission";
 
-import { Permission } from '../../../interfaces/character';
+import { Permission } from "../../../interfaces/character";
 
-import COLOR from '../../../constants/color';
+import COLOR from "../../../constants/color";
 
 const CharacterSetting = ({
   name,
@@ -36,7 +36,7 @@ const CharacterSetting = ({
       <Content>
         <InputAdd
           value={value}
-          placeholder={''}
+          placeholder={""}
           onChange={handleChangeInput}
           reset={reset}
         />
@@ -51,7 +51,7 @@ const CharacterSetting = ({
         </Items>
       </Content>
       <ButtonBig
-        content={'역할 수정하기'}
+        content={"역할 수정하기"}
         color={COLOR.GREEN4}
         onClick={() => {
           editMutation.mutate({
@@ -64,11 +64,11 @@ const CharacterSetting = ({
         }}
       />
       <ButtonBig
-        content={'역할 삭제하기'}
+        content={"역할 삭제하기"}
         color={COLOR.RED2}
         onClick={() => {
           deleteMutation.mutate(name);
-          setChar('Admin');
+          setChar("Admin");
         }}
       />
     </Container>

--- a/src/components/common/CreateButton/index.tsx
+++ b/src/components/common/CreateButton/index.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { Button } from "./style";
 import { PencilWhiteIcon } from "../../Icons/BoardIcons";
+import { Button } from "./style";
 
-const CreateButton = () => {
+const CreateButton = (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
   return (
     <Button>
-      <PencilWhiteIcon /> 작성
+      <PencilWhiteIcon style={{ marginRight: "1rem" }} /> 작성
     </Button>
   );
 };

--- a/src/components/common/CreateButton/style.ts
+++ b/src/components/common/CreateButton/style.ts
@@ -6,7 +6,7 @@ const Button = styled.button`
   color: ${COLOR.WHITE};
   border: none;
   border-radius: 0.6rem;
-  padding: 0.5rem 1rem;
+  padding: 0.7rem 1rem;
 `;
 
 export { Button };

--- a/src/hooks/board/comment/useCommentCreate.tsx
+++ b/src/hooks/board/comment/useCommentCreate.tsx
@@ -1,12 +1,8 @@
 import { useMutation, useQueryClient } from "react-query";
 import { waldregAxios as axios } from "../../../apis/axios";
 import { boardCommentKeys } from "./../../../types/boardKey";
-import { BoardComment } from "./../../../interfaces/board";
 
-async function commentCreate(
-  board_id: number,
-  comment: BoardComment
-): Promise<void> {
+async function commentCreate(board_id: number, comment: string): Promise<void> {
   await axios.post(`/comment/${board_id}`, {
     content: comment,
   });
@@ -18,7 +14,7 @@ interface UseCommentCreate {
 
 export function useCommentCreate(
   board_id: number,
-  comment: BoardComment
+  comment: string
 ): UseCommentCreate {
   const queryClient = useQueryClient();
 

--- a/src/hooks/board/comment/useCommentDelete.tsx
+++ b/src/hooks/board/comment/useCommentDelete.tsx
@@ -7,16 +7,19 @@ async function commentDelete(comment_id: number): Promise<void> {
 }
 
 interface UseCommentDelete {
-  mutate: () => void;
+  mutate: (comment_id: number) => void;
 }
 
 export function useCommentDelete(comment_id: number): UseCommentDelete {
   const queryClient = useQueryClient();
 
-  const { mutate } = useMutation(() => commentDelete(comment_id), {
-    onSuccess: () => {
-      queryClient.invalidateQueries(boardCommentKeys.all);
-    },
-  });
+  const { mutate } = useMutation(
+    (comment_id: number) => commentDelete(comment_id),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(boardCommentKeys.all);
+      },
+    }
+  );
   return { mutate };
 }

--- a/src/interfaces/board.ts
+++ b/src/interfaces/board.ts
@@ -39,7 +39,7 @@ export interface BoardCategoryLists extends BoardCategory {
 }
 
 export interface BoardComment {
-  board_id?: number;
+  id?: number;
   content: string;
 }
 

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -1,4 +1,4 @@
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
 
@@ -9,6 +9,10 @@ const GlobalStyle = createGlobalStyle`
 
 * {
     box-sizing: border-box;
+  }
+
+  svg {
+    display: inline-block;
   }
   
   html,


### PR DESCRIPTION
### 🚩 관련 이슈
- #66 

### 📋 PR Checklist
- [x] 댓글 컴포넌트에서 생성
- [x] 댓글 컴포넌트에서 삭제
- [x] 댓글 리스트 조회
- [x] 댓글 개수 count 기능
- [x] createbutton 컴포넌트 변경


### 📌 유의사항
댓글 수정 기능은 게시판 수정 기능처럼 페이지를 이동할 수 없어서
어떻게 해야될지 좀 더 생각해봐야 될 것 같습니다!

또한, 피그마에 댓글 수정 삭제 관련이 없어서
게시판처럼 수정 삭제 버튼 추가했습니다.

### ✅ 테스트 결과
댓글 갯수도 잘 카운트 됩니다 :)
다들 테스트 해보세용~~~

![image](https://user-images.githubusercontent.com/97819580/219871431-79b18c23-d2f2-4e5e-9c4c-4a7d27bc3123.png)
 
