### PR TITLE
[Fix] 게시판 오류 수정, 파일 데이터 서버에 보내기

### DIFF
--- a/src/components/board/BoardCommentList/index.tsx
+++ b/src/components/board/BoardCommentList/index.tsx
@@ -24,8 +24,10 @@ const BoardCommentList = () => {
       {commentLists?.comments.map((comment) => (
         <CommentDetail key={comment.id}>
           <CommentInformation>
-            <CommentUser style={FONT.SUBTITLE1}>ham0__0</CommentUser>
-            <CommentDate style={FONT.SUBTITLE1}>2023.02.02</CommentDate>
+            <CommentUser style={FONT.SUBTITLE1}>{comment.name}</CommentUser>
+            <CommentDate style={FONT.SUBTITLE1}>
+              {comment.created_at.slice(0, 10)}
+            </CommentDate>
           </CommentInformation>
           <CommentContentBox style={FONT.BODY1}>
             <div>{comment.content}</div>

--- a/src/components/board/BoardCreate/index.tsx
+++ b/src/components/board/BoardCreate/index.tsx
@@ -16,7 +16,7 @@ import BoardFileUpload from "../BoardFileUpload";
 const BoardCreate = () => {
   const [title, setTitle] = useState<string>("");
   const [content, setContent] = useState<string>("");
-  const [file, setFile] = useState<File | null>(null);
+  const [fileList, setFileList] = useState<FileList | null>(null);
   const category_id = useRecoilValue(boardCategoryState);
   const navigate = useNavigate();
 
@@ -35,7 +35,7 @@ const BoardCreate = () => {
     new Blob([JSON.stringify(data)], { type: "application/json" })
   );
 
-  formData.append("file", file!!);
+  // formData.append("file", fileList!![0]);
 
   const createMutation = useBoardCreate(formData);
 

--- a/src/components/board/BoardCreate/index.tsx
+++ b/src/components/board/BoardCreate/index.tsx
@@ -16,7 +16,7 @@ import BoardFileUpload from "../BoardFileUpload";
 const BoardCreate = () => {
   const [title, setTitle] = useState<string>("");
   const [content, setContent] = useState<string>("");
-  const [fileList, setFileList] = useState<FileList | null>(null);
+  const [fileList, setFileList] = useState<File[]>([]);
   const category_id = useRecoilValue(boardCategoryState);
   const navigate = useNavigate();
 
@@ -34,8 +34,6 @@ const BoardCreate = () => {
     "boardCreateRequest",
     new Blob([JSON.stringify(data)], { type: "application/json" })
   );
-
-  // formData.append("file", fileList!![0]);
 
   const createMutation = useBoardCreate(formData);
 
@@ -63,7 +61,7 @@ const BoardCreate = () => {
             setContent(e.currentTarget.value)
           }
         />
-        <BoardFileUpload />
+        <BoardFileUpload formData={formData} />
         <BoardButtonContainer>
           <CreateButton style={FONT.SUBTITLE1} onSubmit={handleCreateSubmit} />
         </BoardButtonContainer>

--- a/src/components/board/BoardCreate/index.tsx
+++ b/src/components/board/BoardCreate/index.tsx
@@ -1,21 +1,21 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useBoardCreate } from '../../../hooks/board/useBoardCreate';
-import { useRecoilValue } from 'recoil';
-import { boardCategoryState } from '../../../states/board';
-import FONT from '../../../constants/fonts';
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useBoardCreate } from "../../../hooks/board/useBoardCreate";
+import { useRecoilValue } from "recoil";
+import { boardCategoryState } from "../../../states/board";
+import FONT from "../../../constants/fonts";
 import {
   BoardButtonContainer,
   BoardContentTextArea,
   BoardTitleInput,
-} from './style';
-import { BoardContainer } from '../BoardDetail/style';
-import CreateButton from '../../common/createbutton';
-import BoardFileUpload from '../BoardFileUpload';
+} from "./style";
+import { BoardContainer } from "../BoardDetail/style";
+import CreateButton from "../../common/createbutton";
+import BoardFileUpload from "../BoardFileUpload";
 
 const BoardCreate = () => {
-  const [title, setTitle] = useState<string>('');
-  const [content, setContent] = useState<string>('');
+  const [title, setTitle] = useState<string>("");
+  const [content, setContent] = useState<string>("");
   const [file, setFile] = useState<File | null>(null);
   const category_id = useRecoilValue(boardCategoryState);
   const navigate = useNavigate();
@@ -26,14 +26,16 @@ const BoardCreate = () => {
     title: title,
     content: content,
     category_id: category_id,
+    views: 0,
+    comment_count: 0,
   };
 
   formData.append(
-    'boardCreateRequest',
-    new Blob([JSON.stringify(data)], { type: 'application/json' })
+    "boardCreateRequest",
+    new Blob([JSON.stringify(data)], { type: "application/json" })
   );
 
-  formData.append('file', file!!);
+  formData.append("file", file!!);
 
   const createMutation = useBoardCreate(formData);
 

--- a/src/components/board/BoardDetail/index.tsx
+++ b/src/components/board/BoardDetail/index.tsx
@@ -16,14 +16,28 @@ import FONT from "./../../../constants/fonts";
 import BoardCommentCreate from "./../BoardCommentCreate/index";
 import BoardCommentList from "./../BoardCommentList/index";
 import { useCommentList } from "../../../hooks/board/comment/useCommentList";
+import { useState } from "react";
+import Modal from "../../common/modal";
+import {
+  CategoryDeleteContent,
+  SettingButtonBox,
+  SettingCancelButton,
+  SettingSaveButton,
+  SettingTitle,
+} from "../../../routes/Setting/Board/style";
 
 const BoardDetail = () => {
   const navigate = useNavigate();
   const { id, categoryId } = useParams<Params>();
   const { board } = useBoardDetail(parseInt(id!!));
+  const [isOpenDeleteModal, setIsOpenDeleteModal] = useState(false);
 
   const handleUpdateButtonClick = () => {
     navigate(`/board/${categoryId}/update/${id}`);
+  };
+
+  const handleIsOpenDeleteModal = () => {
+    setIsOpenDeleteModal((prev) => !prev);
   };
 
   const boardDelete = useBoardDelete(parseInt(id!!));
@@ -35,50 +49,71 @@ const BoardDetail = () => {
   const { commentLists } = useCommentList(parseInt(id!!), 1, 4);
 
   return (
-    <>
-      <BoardContainer>
-        <BoardTitle style={FONT.SUBTITLE1}>{board?.title}</BoardTitle>
-        <BoardTopBox>
-          <BoardInformationBox>
+    <BoardContainer>
+      <BoardTitle style={FONT.SUBTITLE1}>{board?.title}</BoardTitle>
+      <BoardTopBox>
+        <BoardInformationBox>
+          <BoardInformation style={FONT.SUBTITLE1}>
+            {board?.author.name}
+          </BoardInformation>
+          <BoardInformation style={FONT.SUBTITLE1}>
+            작성일 : {board?.created_at.slice(0, 10)}
+          </BoardInformation>
+          {board?.created_at !== board?.last_modified_at && (
             <BoardInformation style={FONT.SUBTITLE1}>
-              {board?.author.name}
+              수정일 : {board?.last_modified_at.slice(0, 10)}
             </BoardInformation>
-            <BoardInformation style={FONT.SUBTITLE1}>
-              작성일 : {board?.created_at.slice(0, 10)}
-            </BoardInformation>
-            {board?.created_at !== board?.last_modified_at && (
-              <BoardInformation style={FONT.SUBTITLE1}>
-                수정일 : {board?.last_modified_at.slice(0, 10)}
-              </BoardInformation>
-            )}
-            <BoardInformation style={FONT.SUBTITLE1}>
-              조회수 : {board?.views}
-            </BoardInformation>
-          </BoardInformationBox>
-          <BoardButtonBox>
-            <BoardButton
-              style={FONT.SUBTITLE1}
-              onClick={handleUpdateButtonClick}
-            >
-              수정
-            </BoardButton>
-            <BoardButton
-              style={FONT.SUBTITLE1}
-              onClick={handleDeleteButtonClick}
-            >
-              삭제
-            </BoardButton>
-          </BoardButtonBox>
-        </BoardTopBox>
-        <BoardContent style={FONT.BODY1}>{board?.content}</BoardContent>
+          )}
+          <BoardInformation style={FONT.SUBTITLE1}>
+            조회수 : {board?.views}
+          </BoardInformation>
+        </BoardInformationBox>
+        <BoardButtonBox>
+          <BoardButton style={FONT.SUBTITLE1} onClick={handleUpdateButtonClick}>
+            수정
+          </BoardButton>
+          <BoardButton
+            style={FONT.SUBTITLE1}
+            onClick={() => setIsOpenDeleteModal((prev) => !prev)}
+          >
+            삭제
+          </BoardButton>
+        </BoardButtonBox>
+      </BoardTopBox>
+      <BoardContent style={FONT.BODY1}>{board?.content}</BoardContent>
 
-        <BoardCommentCount style={FONT.SUBTITLE2}>
-          {commentLists?.max_idx}개의 댓글
-        </BoardCommentCount>
-        <BoardCommentCreate />
-        <BoardCommentList />
-      </BoardContainer>
-    </>
+      <BoardCommentCount style={FONT.SUBTITLE2}>
+        {commentLists?.max_idx}개의 댓글
+      </BoardCommentCount>
+      <BoardCommentCreate />
+      <BoardCommentList />
+
+      {isOpenDeleteModal && (
+        <Modal onClickToggleModal={handleIsOpenDeleteModal} size={"small"}>
+          <SettingTitle style={FONT.HEADING}>게시글 삭제</SettingTitle>
+          <CategoryDeleteContent style={FONT.SUBTITLE2}>
+            게시글을 삭제하시겠습니까?
+          </CategoryDeleteContent>
+          <SettingButtonBox>
+            <SettingCancelButton
+              style={FONT.SUBTITLE2}
+              onClick={handleIsOpenDeleteModal}
+            >
+              취소
+            </SettingCancelButton>
+            <SettingSaveButton
+              style={FONT.SUBTITLE2}
+              onClick={() => {
+                handleDeleteButtonClick();
+                handleIsOpenDeleteModal();
+              }}
+            >
+              확인
+            </SettingSaveButton>
+          </SettingButtonBox>
+        </Modal>
+      )}
+    </BoardContainer>
   );
 };
 

--- a/src/components/board/BoardDetail/index.tsx
+++ b/src/components/board/BoardDetail/index.tsx
@@ -52,7 +52,7 @@ const BoardDetail = () => {
               </BoardInformation>
             )}
             <BoardInformation style={FONT.SUBTITLE1}>
-              조회수 : 152
+              조회수 : {board?.views}
             </BoardInformation>
           </BoardInformationBox>
           <BoardButtonBox>

--- a/src/components/board/BoardFileUpload/index.tsx
+++ b/src/components/board/BoardFileUpload/index.tsx
@@ -18,75 +18,23 @@ import {
 const BoardFileUpload = () => {
   const [fileList, setFileList] = useState<Array<File>>([]);
 
+  // TODO: 파일 다중 업로드 구현
   const handleInputFiles = (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
-    handleFiles(e.target.files as FileList);
-  };
-
-  const handleInputFile = (e: ChangeEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    handleFile(e.target.files![0]);
+    const files = e.target.files;
+    handleUpdateFiles(files!!);
   };
 
   const handleDropFiles = (e: DragEvent<HTMLDivElement>) => {
-    console.log({ e }, e.dataTransfer.files);
     e.preventDefault();
-
-    handleFiles(e.dataTransfer.files);
+    const files = e.dataTransfer.files;
+    handleUpdateFiles(files!!);
   };
 
-  const handleFiles = (files: FileList) => {
-    let fileList: Array<File> = [];
-
-    if (files.length > 5) {
-      alert(`파일 개수가 초과되었습니다.(최대 5개)`);
-      return;
-    }
-
+  const handleUpdateFiles = (files: FileList) => {
     for (let i = 0; i < files.length; i++) {
       const file: File = files[i];
-      const format: string = `${file.name.split(".").slice(-1)}`.toUpperCase();
-
-      if (
-        format === "JPG" ||
-        format === "JPEG" ||
-        format === "PNG" ||
-        format === "PDF"
-      ) {
-        fileList = [...fileList, file];
-      } else {
-        alert(
-          `파일 포맷을 확인해주세요.업로드 된 파일 이름 ${file.name} / 포맷 ${format}`
-        );
-        return;
-      }
-    }
-
-    if (fileList.length > 0) {
-      setFileList(fileList);
-    }
-  };
-
-  const handleFile = (file: File): void => {
-    if (fileList.length > 4) {
-      alert(`파일 개수가 초과되었습니다`);
-      return;
-    }
-    const updateFile: File = file;
-    const format: string = `${file.name.split(".").slice(-1)}`.toUpperCase();
-
-    if (
-      format === "JPG" ||
-      format === "JPEG" ||
-      format === "PNG" ||
-      format === "PDF"
-    ) {
-      setFileList([...fileList, updateFile]);
-    } else {
-      alert(
-        `파일 포맷을 확인해주세요.업로드 된 파일 이름 ${file.name} / 포맷 ${format}`
-      );
-      return;
+      setFileList([...fileList, file]);
     }
   };
 
@@ -133,7 +81,6 @@ const BoardFileUpload = () => {
               </FileDetailBox>
             );
           })}
-
           <FilePlusLabel htmlFor="input_file" className="span">
             <PlusIcon />
           </FilePlusLabel>
@@ -141,7 +88,7 @@ const BoardFileUpload = () => {
             id="input_file"
             type="file"
             multiple
-            onChange={handleInputFile}
+            onChange={handleInputFiles}
           />
         </FileListBox>
       )}

--- a/src/components/board/BoardFileUpload/index.tsx
+++ b/src/components/board/BoardFileUpload/index.tsx
@@ -16,8 +16,12 @@ import {
   FileTitleBox,
 } from "./style";
 
-const BoardFileUpload = () => {
-  const [fileList, setFileList] = useState<Array<File>>([]);
+interface BoardFileUploadProps {
+  formData: FormData;
+}
+
+const BoardFileUpload = ({ formData }: BoardFileUploadProps) => {
+  const [fileList, setFileList] = useState<File[]>([]);
 
   // TODO: 파일 다중 업로드 구현
   const handleInputFiles = (e: ChangeEvent<HTMLInputElement>) => {
@@ -36,15 +40,17 @@ const BoardFileUpload = () => {
     for (let i = 0; i < files.length; i++) {
       const file: File = files[i];
       setFileList([...fileList, file]);
+      formData.append("file", file);
     }
-  };
-
-  const dragOver = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
   };
 
   const handleDeleteFile = (index: number) => {
     setFileList(fileList.filter((_, i) => i !== index));
+    formData.delete("file");
+  };
+
+  const dragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
   };
 
   return (

--- a/src/components/board/BoardFileUpload/index.tsx
+++ b/src/components/board/BoardFileUpload/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { ChangeEvent, DragEvent, useState } from "react";
 import { FileDeleteIcon, FileIcon } from "../../Icons/BoardIcons";
 import { PlusIcon } from "../../Icons/SettingIcons";

--- a/src/components/board/BoardFileUpload/style.ts
+++ b/src/components/board/BoardFileUpload/style.ts
@@ -55,6 +55,7 @@ const FileDetailBox = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-bottom: 0.4rem;
 `;
 
 const FileDetailTitle = styled.div`
@@ -67,6 +68,7 @@ const FilePlusLabel = styled.label`
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-bottom: 0.4rem;
 `;
 
 export {

--- a/src/components/board/BoardList/index.tsx
+++ b/src/components/board/BoardList/index.tsx
@@ -4,6 +4,7 @@ import {
   BoardContentBox,
   BoardInformation,
   BoardInformationBox,
+  BoardInformationText,
   BoardTitle,
 } from "./style";
 import { useNavigate } from "react-router-dom";
@@ -37,11 +38,11 @@ function BoardList({ boardList }: BoardListProps) {
             <BoardTitle style={FONT.SUBTITLE2}>{board.title}</BoardTitle>
             <BoardContent style={FONT.SUBTITLE2}>
               <CommentIcon />
-              12
+              {board.comment_count}
             </BoardContent>
             <BoardContent style={FONT.SUBTITLE2}>
               <ViewIcon />
-              152
+              <BoardInformationText>{board.views}</BoardInformationText>
             </BoardContent>
           </BoardContentBox>
         </BoardContainer>

--- a/src/components/board/BoardList/style.ts
+++ b/src/components/board/BoardList/style.ts
@@ -5,19 +5,23 @@ const BoardContainer = styled.div`
   display: flex;
   flex-direction: column;
   border-bottom: 2px solid ${COLOR.GRAY1};
-  padding: 1.4rem 0;
+  padding: 1.1rem 0;
   cursor: pointer;
 `;
 
 const BoardInformationBox = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 0.6rem;
 `;
 
 const BoardInformation = styled.div`
   color: ${COLOR.GRAY3};
   margin-right: 1rem;
+`;
+
+const BoardInformationText = styled.div`
+  margin-left: 0.3rem;
 `;
 
 const BoardContentBox = styled.div`
@@ -26,7 +30,7 @@ const BoardContentBox = styled.div`
 
 const BoardTitle = styled.div`
   color: ${COLOR.GRAY5};
-  margin-right: 1rem;
+  margin-right: 1.5rem;
 `;
 
 const BoardContent = styled.div`
@@ -40,6 +44,7 @@ export {
   BoardContainer,
   BoardInformationBox,
   BoardInformation,
+  BoardInformationText,
   BoardContentBox,
   BoardTitle,
   BoardContent,

--- a/src/components/board/BoardUpdate/index.tsx
+++ b/src/components/board/BoardUpdate/index.tsx
@@ -20,7 +20,7 @@ const BoardUpdate = () => {
 
   const [title, setTitle] = useState(board?.title);
   const [content, setContent] = useState(board?.content);
-  const [file, setFile] = useState<File | null>(null);
+  const [fileList, setFileList] = useState<File[]>([]);
   const category_id = useRecoilValue(boardCategoryState);
   const formData = new FormData();
   const navigate = useNavigate();
@@ -36,8 +36,6 @@ const BoardUpdate = () => {
     "boardUpdateRequest",
     new Blob([JSON.stringify(data)], { type: "application/json" })
   );
-
-  formData.append("file", file!!);
 
   const updateMutation = useBoardUpdate(parseInt(id!!), formData);
 
@@ -65,16 +63,8 @@ const BoardUpdate = () => {
             setContent(e.currentTarget.value)
           }
         />
-        <BoardFileUpload />
-        {/* <BoardFileInput
-          style={FONT.SUBTITLE2}
-          type="file"
-          onChange={(e: React.FormEvent<HTMLInputElement>) => {
-            if (e.currentTarget.files) {
-              setFile(e.currentTarget.files[0]);
-            }
-          }}
-        /> */}
+        <BoardFileUpload formData={formData} />
+
         <BoardButtonContainer>
           <CreateButton onSubmit={handleUpdateSubmit} style={FONT.SUBTITLE1} />
         </BoardButtonContainer>

--- a/src/components/board/BoardUpdate/index.tsx
+++ b/src/components/board/BoardUpdate/index.tsx
@@ -1,18 +1,18 @@
-import { useState } from 'react';
-import { Params, useNavigate, useParams } from 'react-router';
-import { useRecoilValue } from 'recoil';
-import FONT from '../../../constants/fonts';
-import { useBoardDetail } from '../../../hooks/board/useBoardDetail';
-import { boardCategoryState } from '../../../states/board';
-import CreateButton from '../../common/createbutton';
+import { useState } from "react";
+import { Params, useNavigate, useParams } from "react-router";
+import { useRecoilValue } from "recoil";
+import FONT from "../../../constants/fonts";
+import { useBoardDetail } from "../../../hooks/board/useBoardDetail";
+import { boardCategoryState } from "../../../states/board";
+import CreateButton from "../../common/createbutton";
 import {
   BoardButtonContainer,
   BoardContentTextArea,
   BoardTitleInput,
-} from '../BoardCreate/style';
-import { BoardContainer } from '../BoardDetail/style';
-import BoardFileUpload from '../BoardFileUpload';
-import { useBoardUpdate } from './../../../hooks/board/useBoardUpdate';
+} from "../BoardCreate/style";
+import { BoardContainer } from "../BoardDetail/style";
+import BoardFileUpload from "../BoardFileUpload";
+import { useBoardUpdate } from "./../../../hooks/board/useBoardUpdate";
 
 const BoardUpdate = () => {
   const { id } = useParams<Params>();
@@ -33,11 +33,11 @@ const BoardUpdate = () => {
   };
 
   formData.append(
-    'boardUpdateRequest',
-    new Blob([JSON.stringify(data)], { type: 'application/json' })
+    "boardUpdateRequest",
+    new Blob([JSON.stringify(data)], { type: "application/json" })
   );
 
-  formData.append('file', file!!);
+  formData.append("file", file!!);
 
   const updateMutation = useBoardUpdate(parseInt(id!!), formData);
 

--- a/src/interfaces/board.ts
+++ b/src/interfaces/board.ts
@@ -43,6 +43,9 @@ export interface BoardCategoryLists extends BoardCategory {
 export interface BoardComment {
   id?: number;
   content: string;
+  name: string;
+  created_at: string;
+  last_modified_at: string;
 }
 
 export interface BoardCommentLists extends BoardComment {

--- a/src/interfaces/board.ts
+++ b/src/interfaces/board.ts
@@ -9,6 +9,8 @@ export interface Board {
   };
   created_at: string;
   last_modified_at: string;
+  views: number;
+  comment_count: number;
   images?: [];
   exist_file: boolean;
   files?: [];

--- a/src/routes/Setting/Board/index.tsx
+++ b/src/routes/Setting/Board/index.tsx
@@ -1,15 +1,15 @@
-import React, { useCallback, useState } from 'react';
-import BoardCategoryList from '../../../components/board/BoardCategoryList';
-import { PlusIcon } from '../../../components/Icons/SettingIcons';
-import { useBoardCategoryCreate } from '../../../hooks/board/category/useBoardCategoryCreate';
-import { useBoardCategoryList } from '../../../hooks/board/category/useBoardCategoryList';
-import FONT from './../../../constants/fonts';
-import Modal from '../../../components/common/modal';
+import React, { useCallback, useState } from "react";
+import BoardCategoryList from "../../../components/board/BoardCategoryList";
+import { PlusIcon } from "../../../components/Icons/SettingIcons";
+import { useBoardCategoryCreate } from "../../../hooks/board/category/useBoardCategoryCreate";
+import { useBoardCategoryList } from "../../../hooks/board/category/useBoardCategoryList";
+import FONT from "./../../../constants/fonts";
+import Modal from "../../../components/common/modal";
 import {
   settingCategoryId,
   settingCategoryName,
   settingFromState,
-} from './../../../states/board';
+} from "./../../../states/board";
 import {
   CategoryDeleteButton,
   CategoryDeleteContent,
@@ -24,13 +24,13 @@ import {
   SettingSaveButton,
   SettingTitle,
   SettingTop,
-} from './style';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { useBoardCategoryUpdate } from '../../../hooks/board/category/useBoardCategoryUpdate';
-import { useBoardCategoryDelete } from '../../../hooks/board/category/useBoardCategoryDelete';
+} from "./style";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { useBoardCategoryUpdate } from "../../../hooks/board/category/useBoardCategoryUpdate";
+import { useBoardCategoryDelete } from "../../../hooks/board/category/useBoardCategoryDelete";
 
 const BoardManagement = () => {
-  const [boardName, setBoardName] = useState<string>('');
+  const [boardName, setBoardName] = useState<string>("");
   const { boardCategoryList } = useBoardCategoryList();
 
   const [isOpenCreateModal, setIsOpenCreateModal] = useState(false);
@@ -46,7 +46,7 @@ const BoardManagement = () => {
 
   const handleCreateCategory = () => {
     createMutation.mutate();
-    setBoardName('');
+    setBoardName("");
     setIsOpenCreateModal(false);
   };
 
@@ -57,7 +57,7 @@ const BoardManagement = () => {
 
   const handleClickCreateModal = useCallback(() => {
     setIsOpenCreateModal(!isOpenCreateModal);
-    setBoardName('');
+    setBoardName("");
   }, [isOpenCreateModal]);
 
   const handleClickDeleteModal = useCallback(() => {
@@ -66,7 +66,7 @@ const BoardManagement = () => {
 
   return (
     <>
-      <SettingContainer style={{ width: '30%' }}>
+      <SettingContainer style={{ width: "30%" }}>
         <SettingTop>
           <SettingTitle style={FONT.HEADING}>게시판</SettingTitle>
           <button onClick={handleClickCreateModal}>
@@ -81,7 +81,7 @@ const BoardManagement = () => {
       </SettingContainer>
 
       {settingForm && (
-        <SettingFormContainer style={{ width: '50%' }}>
+        <SettingFormContainer style={{ width: "50%" }}>
           <div>
             <SettingTop>
               <SettingTitle style={FONT.HEADING}>설정</SettingTitle>
@@ -116,7 +116,7 @@ const BoardManagement = () => {
       )}
 
       {isOpenCreateModal && (
-        <Modal onClickToggleModal={handleClickCreateModal} size={'small'}>
+        <Modal onClickToggleModal={handleClickCreateModal} size={"small"}>
           <SettingTitle style={FONT.HEADING}>게시판 추가</SettingTitle>
           <SettingInput
             type="text"
@@ -145,7 +145,7 @@ const BoardManagement = () => {
       )}
 
       {isOpenDeleteModal && (
-        <Modal onClickToggleModal={handleClickDeleteModal}>
+        <Modal onClickToggleModal={handleClickDeleteModal} size={"small"}>
           <SettingTitle style={FONT.HEADING}>게시판 삭제</SettingTitle>
           <CategoryDeleteContent style={FONT.SUBTITLE2}>
             <CategoryDeleteSpan>{categoryName}</CategoryDeleteSpan> 게시판을


### PR DESCRIPTION
### 🚩 관련 이슈
- #67 

### 📋 PR Checklist
- [x] 게시판 카테고리 삭제 모달 사이즈 줄이기
- [x] 게시글 삭제 모달 생성
- [x] 파일 확장자 없애기
- [x] 파일 선택한 거 서버에 보내기
- [x] 게시글 조회수 추가 
- [x] 게시글 리스트에서 댓글 개수 추가
- [x] 게시판 댓글 생성일, 수정일, 로그인 한 계정

### 📌 유의사항
현재 게시글 디테일 부분에 파일 이름으로 뜨게 하는 거랑 다운로드 할 수 있게 하려는데
쉽지 않네요 ... 좀 오래 걸릴듯 합니다.

### ✅ 테스트 결과
![image](https://user-images.githubusercontent.com/97819580/220919342-63f3a771-e718-43ab-9ede-6c3d836cc78e.png)

![image](https://user-images.githubusercontent.com/97819580/220919278-ce82df8b-4ea7-4f8e-8e60-456124dd71f0.png)

