### PR TITLE
[Fix] 게시판 QueryKey 오류

### DIFF
--- a/src/components/board/BoardCreate/index.tsx
+++ b/src/components/board/BoardCreate/index.tsx
@@ -35,7 +35,6 @@ const BoardCreate = () => {
   const handleCreateSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault();
     createMutation.mutate();
-    navigate(-1);
   };
 
   return (

--- a/src/components/board/BoardUpdate/index.tsx
+++ b/src/components/board/BoardUpdate/index.tsx
@@ -40,7 +40,6 @@ const BoardUpdate = () => {
   const handleUpdateSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault();
     updateMutation.mutate();
-    navigate(-1);
   };
 
   return (

--- a/src/hooks/board/category/useBoardCategoryCreate.tsx
+++ b/src/hooks/board/category/useBoardCategoryCreate.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "react-query";
 import { waldregAxios as axios } from "../../../apis/axios";
 import { boardCategoryKeys } from "../../../types/boardKey";
 
-async function createboardCategory(name: string): Promise<void> {
+async function boardCategoryCreate(name: string): Promise<void> {
   await axios.post(`/category`, {
     category_name: name,
   });
@@ -15,7 +15,7 @@ interface UseBoardCategoryCreate {
 export function useBoardCategoryCreate(name: string): UseBoardCategoryCreate {
   const queryClient = useQueryClient();
 
-  const { mutate } = useMutation(() => createboardCategory(name), {
+  const { mutate } = useMutation(() => boardCategoryCreate(name), {
     onSuccess: () => {
       queryClient.invalidateQueries(boardCategoryKeys.all);
     },

--- a/src/hooks/board/category/useBoardCategoryDelete.tsx
+++ b/src/hooks/board/category/useBoardCategoryDelete.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "react-query";
 import { waldregAxios as axios } from "../../../apis/axios";
 import { boardCategoryKeys } from "../../../types/boardKey";
 
-async function deleteBoardCategory(id: number) {
+async function BoardCategoryDelete(id: number) {
   await axios.delete(`/category/${id}`);
 }
 
@@ -13,7 +13,7 @@ interface UseBoardCategoryDelete {
 export function useBoardCategoryDelete(): UseBoardCategoryDelete {
   const queryClient = useQueryClient();
 
-  const { mutate } = useMutation((id: number) => deleteBoardCategory(id), {
+  const { mutate } = useMutation((id: number) => BoardCategoryDelete(id), {
     onSuccess: () => {
       queryClient.invalidateQueries(boardCategoryKeys.all);
     },

--- a/src/hooks/board/useBoardCreate.tsx
+++ b/src/hooks/board/useBoardCreate.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "react-query";
 import { boardKeys } from "../../types/boardKey";
 import { waldregAxios as axios } from "./../../apis/axios";
+import { useNavigate } from "react-router-dom";
 
 async function boardCreate(board: any): Promise<void> {
   await axios.post(`/board`, board, {
@@ -16,10 +17,12 @@ interface UseBoardCreate {
 
 export function useBoardCreate(board: any): UseBoardCreate {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { mutate } = useMutation(() => boardCreate(board), {
-    onSuccess: () => {
-      queryClient.invalidateQueries(boardKeys.all);
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(boardKeys.all);
+      return navigate(-1);
     },
   });
   return { mutate };

--- a/src/hooks/board/useBoardDelete.tsx
+++ b/src/hooks/board/useBoardDelete.tsx
@@ -1,23 +1,26 @@
 import { useMutation, useQueryClient } from "react-query";
 import { boardKeys } from "../../types/boardKey";
 import { waldregAxios as axios } from "./../../apis/axios";
+import { useNavigate } from "react-router-dom";
 
-async function boardDelete(id: number) {
-  const { data } = await axios.delete(`/board/${id}`);
-  return data;
+async function boardDelete(id: number): Promise<void> {
+  await axios.delete(`/board/${id}`);
 }
 
 interface UseBoardDelete {
   mutate: () => void;
 }
 
-export function useBoardDelete(id: number): UseBoardDelete {
+export function useBoardDelete(id: number, categoryId: number): UseBoardDelete {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { mutate } = useMutation(() => boardDelete(id), {
     onSuccess: () => {
       queryClient.invalidateQueries(boardKeys.all);
+      navigate(`/board/${categoryId}`);
     },
   });
+
   return { mutate };
 }

--- a/src/hooks/board/useBoardUpdate.tsx
+++ b/src/hooks/board/useBoardUpdate.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "react-query";
 import { boardKeys } from "../../types/boardKey";
 import { waldregAxios as axios } from "./../../apis/axios";
+import { useNavigate } from "react-router-dom";
 
 async function boardUpdate(id: number, board: any): Promise<void> {
   await axios.post(`/board/${id}`, board, {
@@ -16,10 +17,12 @@ interface UseBoardUpdate {
 
 export function useBoardUpdate(id: number, board: any): UseBoardUpdate {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const { mutate } = useMutation(() => boardUpdate(id, board), {
-    onSuccess: () => {
-      queryClient.invalidateQueries(boardKeys.detail(id));
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(boardKeys.detail(id));
+      return navigate(-1);
     },
   });
   return { mutate };

--- a/src/routes/Board/BoardDetail/index.tsx
+++ b/src/routes/Board/BoardDetail/index.tsx
@@ -49,10 +49,9 @@ const BoardDetail = () => {
     setIsOpenDeleteModal((prev) => !prev);
   };
 
-  const boardDelete = useBoardDelete(parseInt(id!!));
+  const deleteMutation = useBoardDelete(parseInt(id!!), parseInt(categoryId!!));
   const handleDeleteButtonClick = () => {
-    boardDelete.mutate();
-    navigate(-1);
+    deleteMutation.mutate();
   };
 
   async function getBoardDownload(file_id: string): Promise<any> {


### PR DESCRIPTION
### 🚩 관련 이슈
- close #140 

### 📋 PR Checklist
- [x] 게시판 생성 오류 해결
- [x] 게시판 삭제 오류 해결
- [x] 게시판 수정 오류 해결

### 📌 유의사항
onSuccess callback을 비동기 처리해서 해결했습니다! await의 효과를 이용해서 onSuccess callback 이 실행될때 쿼리를 invalidate를 시키는 함수 실행의 결과를 기다리게 하고 이후 네비게이션을 시키는 방식으로 비동기적인 callback을 동기처럼 작동하게 함으로써, 문제를 해결했습니다.

++ 삽질로 인한 소요시간... 6h

### ✅ 테스트 결과

https://github.com/waldreg/waldreg-client/assets/97819580/5b196abc-93a4-4782-9e76-b14d4500baba


